### PR TITLE
리스트페이지에서 글쓰기페이지로 넘어갈 때 선택한 카테고리 유지되게

### DIFF
--- a/src/templates/post/context/currentCategory.context.ts
+++ b/src/templates/post/context/currentCategory.context.ts
@@ -1,0 +1,7 @@
+import { atom } from "jotai";
+import { PostCategoryType } from "../types";
+import { CATEGORY } from "../constants";
+
+const currentCategoryContext = atom<PostCategoryType>(CATEGORY.COMMON);
+
+export default currentCategoryContext;

--- a/src/templates/post/context/index.ts
+++ b/src/templates/post/context/index.ts
@@ -1,0 +1,1 @@
+export { default as currentCategory } from "./currentCategory.context";

--- a/src/templates/post/context/index.ts
+++ b/src/templates/post/context/index.ts
@@ -1,1 +1,1 @@
-export { default as currentCategory } from "./currentCategory.context";
+export { default as currentCategoryContext } from "./currentCategory.context";

--- a/src/templates/post/hooks/usePost.ts
+++ b/src/templates/post/hooks/usePost.ts
@@ -3,17 +3,17 @@ import { useRouter } from "next/navigation";
 import dayjs from "dayjs";
 import React from "react";
 import Swal from "sweetalert2";
+import { useAtom } from "jotai";
 import { useUser } from "@/@user/hooks";
 import { KEY, ROUTER } from "@/constants";
-import { CATEGORY } from "../constants";
 import { defaultPostData } from "../assets/data";
 import { useDeletePostMutation } from "../services/post/mutation.service";
 import { Post, PostCategoryType } from "../types";
+import currentCategoryContext from "../context/currentCategory.context";
 
 const usePost = (defaultPostDataState?: Post) => {
   const [postData, setPostData] = React.useState<Post>(defaultPostData);
-  const [currentCategory, setCurrentCategory] =
-    React.useState<PostCategoryType>(CATEGORY.COMMON);
+  const [currentCategory, setCurrentCategory] = useAtom(currentCategoryContext);
   const { mutate: deletePostMutate } = useDeletePostMutation();
   const { user } = useUser();
 

--- a/src/templates/post/hooks/usePost.ts
+++ b/src/templates/post/hooks/usePost.ts
@@ -9,7 +9,7 @@ import { KEY, ROUTER } from "@/constants";
 import { defaultPostData } from "../assets/data";
 import { useDeletePostMutation } from "../services/post/mutation.service";
 import { Post, PostCategoryType } from "../types";
-import currentCategoryContext from "../context/currentCategory.context";
+import { currentCategoryContext } from "../context";
 
 const usePost = (defaultPostDataState?: Post) => {
   const [postData, setPostData] = React.useState<Post>(defaultPostData);

--- a/src/templates/post/hooks/usePostWritable.ts
+++ b/src/templates/post/hooks/usePostWritable.ts
@@ -9,7 +9,7 @@ import {
 } from "../services/post/mutation.service";
 import { Post, PostCategoryType, PostData } from "../types";
 import { defaultPostData } from "../assets/data";
-import currentCategoryContext from "../context/currentCategory.context";
+import { currentCategoryContext } from "../context";
 
 // edit과 write를 동시에 처리하는 훅
 const usePostWritable = (defaultPostDataState?: Post) => {

--- a/src/templates/post/hooks/usePostWritable.ts
+++ b/src/templates/post/hooks/usePostWritable.ts
@@ -1,5 +1,7 @@
 import React from "react";
+import { useAtom } from "jotai";
 import { useImageUpload } from "@/hooks";
+import { useUser } from "@/@user/hooks";
 import { getFilteredPostDataByCategory, getPostIsValid } from "../helpers";
 import {
   useCreatePostMutation,
@@ -7,10 +9,19 @@ import {
 } from "../services/post/mutation.service";
 import { Post, PostCategoryType, PostData } from "../types";
 import { defaultPostData } from "../assets/data";
+import currentCategoryContext from "../context/currentCategory.context";
 
 // edit과 write를 동시에 처리하는 훅
 const usePostWritable = (defaultPostDataState?: Post) => {
-  const [postData, setPostData] = React.useState<Post>(defaultPostData);
+  const { isAdmin } = useUser();
+  const [currentCategory] = useAtom(currentCategoryContext);
+
+  const is유저가공지사항접근 = !isAdmin && currentCategory === "NOTICE";
+
+  const [postData, setPostData] = React.useState<Post>({
+    ...defaultPostData,
+    category: is유저가공지사항접근 ? "COMMON" : currentCategory,
+  });
   const [lostImageUrl, setLostImageUrl] = React.useState();
   const { mutate: updatePostMutate } = useUpdatePostMutation();
   const { mutate: createPostMutate } = useCreatePostMutation();


### PR DESCRIPTION
## 작업사항
post 리스트페이지 -> 글쓰기페이지 이동 시 내가 선택하고 있던 카테고리가 그대로 유지되는 코드를 구현하였습니다
일반 유저가 공지사항을 접근할 수 없게 예외처리를 하였습니다
## 변경한 점

## 스크린샷
