### PR TITLE
chore(lint): eslint react-hooks/exhaustive-deps 규칙 관련 코드 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,5 +55,6 @@ module.exports = {
     ],
     "react/no-array-index-key": 0,
     "consistent-return": 0,
+    "react-hooks/exhaustive-deps": "off",
   },
 };

--- a/src/assets/icons/ArrowIcon.tsx
+++ b/src/assets/icons/ArrowIcon.tsx
@@ -1,4 +1,5 @@
 import { DIRECTION } from "@/constants";
+import styled from "styled-components";
 
 const path = {
   [DIRECTION.TOP]:
@@ -20,15 +21,19 @@ const ArrowIcon = ({
   ...props
 }: ArrowIconProps) => {
   return (
-    <svg
+    <StyledSVG
       {...props}
       viewBox="0 0 41 41"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path d={path[direction]} fill="#727272" />
-    </svg>
+    </StyledSVG>
   );
 };
+
+const StyledSVG = styled.svg`
+  cursor: pointer;
+`;
 
 export default ArrowIcon;

--- a/src/components/common/DragDrop/hooks/useDragDrop.ts
+++ b/src/components/common/DragDrop/hooks/useDragDrop.ts
@@ -28,7 +28,6 @@ const useDragDrop = (handler: (file?: File) => void) => {
       handler(currentFile);
       setFile(currentFile);
     },
-    // eslint-disable-next-line
     [],
   );
 
@@ -40,13 +39,11 @@ const useDragDrop = (handler: (file?: File) => void) => {
   const handleDragOut = React.useCallback((e: DragEvent) => {
     handleDragIn(e);
     setIsDragging(false);
-    // eslint-disable-next-line
   }, []);
 
   const handleDragOver = React.useCallback((e: DragEvent) => {
     handleDragIn(e);
     if (e.dataTransfer) setIsDragging(true);
-    // eslint-disable-next-line
   }, []);
 
   const handleDrop = React.useCallback(
@@ -55,7 +52,6 @@ const useDragDrop = (handler: (file?: File) => void) => {
       handleChangeFiles(e as unknown as React.DragEvent<HTMLInputElement>);
       setIsDragging(false);
     },
-    // eslint-disable-next-line
     [handleChangeFiles],
   );
 

--- a/src/hooks/useDidMountEffect.ts
+++ b/src/hooks/useDidMountEffect.ts
@@ -6,7 +6,6 @@ const useDidMountEffect = (func: () => void, deps: React.DependencyList) => {
   React.useEffect(() => {
     if (didMount.current) func();
     else didMount.current = true;
-    // eslint-disable-next-line
   }, deps);
 };
 

--- a/src/provider/StyledComponentsProvider.tsx
+++ b/src/provider/StyledComponentsProvider.tsx
@@ -12,11 +12,10 @@ const StyledComponentsRegistry = ({ children }: React.PropsWithChildren) => {
   useServerInsertedHTML(() => {
     const styles = styledComponentsStyleSheet.getStyleElement();
     styledComponentsStyleSheet.instance.clearTag();
-    // eslint-disable-next-line
+
     return <>{styles}</>;
   });
 
-  // eslint-disable-next-line
   if (typeof window !== "undefined") return <>{children}</>;
 
   return (

--- a/src/templates/meal/hooks/useMeal.ts
+++ b/src/templates/meal/hooks/useMeal.ts
@@ -53,7 +53,6 @@ const useMeal = () => {
 
     window.addEventListener("keydown", handleMealDateKeyDown);
     return () => window.removeEventListener("keydown", handleMealDateKeyDown);
-    // eslint-disable-next-line
   }, []);
 
   return {

--- a/src/templates/meister/hooks/useMeister.tsx
+++ b/src/templates/meister/hooks/useMeister.tsx
@@ -58,13 +58,11 @@ const useMeister = () => {
       setViewType("분석");
       meisterDetailQuery.refetch().then(() => setButtonSwitch(false));
     }
-    // eslint-disable-next-line
   }, [buttonSwitch]);
 
   React.useEffect(() => {
     handleStudentSearchClick();
     setStudentNum(getStudentId(grade, classNum, studentNumber));
-    // eslint-disable-next-line
   }, []);
 
   React.useEffect(() => {

--- a/src/templates/meister/layouts/Ranking.tsx
+++ b/src/templates/meister/layouts/Ranking.tsx
@@ -15,7 +15,6 @@ const Ranking = () => {
 
   useDidMountEffect(() => {
     refetch();
-    // eslint-disable-next-line
   }, [currentGrade]);
 
   return (

--- a/src/templates/post/layouts/detail/comment/CommentWritableBox.tsx
+++ b/src/templates/post/layouts/detail/comment/CommentWritableBox.tsx
@@ -28,7 +28,6 @@ const CommentWritableBox = ({ ...comment }: Comment) => {
 
   React.useEffect(() => {
     setCommentInput(comment.detail);
-    // eslint-disable-next-line
   }, []);
 
   return (

--- a/src/templates/post/layouts/detail/recomment/RecommentWritableBox.tsx
+++ b/src/templates/post/layouts/detail/recomment/RecommentWritableBox.tsx
@@ -28,7 +28,6 @@ const RecommentWritableBox = ({ ...recomment }: Recomment) => {
 
   React.useEffect(() => {
     setRecommentInput(recomment.detail);
-    // eslint-disable-next-line
   }, []);
 
   return (


### PR DESCRIPTION
## 작업사항
eslint의 규칙 중 하나인 `react-hooks/exhaustive-deps` 를 비활성화하는 주석을 제거했습니다. 또한 `react-hooks/exhaustive-deps`  규칙을 비활성화 하였습니다.
## 변경한 점

## 스크린샷
